### PR TITLE
Add Travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ install:
   - composer install
 
 script:
+  - vendor/bin/phpunit -c etc/phpunit/phpunit.xml
   - vendor/bin/phpcs --standard=etc/phpcs/ruleset-src.xml --extensions=php -n --report=checkstyle --report-file=./build/checkstyle-src.xml
   - vendor/bin/phpcs --standard=etc/phpcs/ruleset-tests.xml --extensions=php -n --report=checkstyle --report-file=./build/checkstyle-tests.xml
-  - vendor/bin/phpunit -c etc/phpunit/phpunit.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: php
+php:
+  - '5.6'
+  - '7.0'
+  - '7.1'
+
+install:
+  - composer install
+
+script:
+  - vendor/bin/phpcs --standard=etc/phpcs/ruleset-src.xml --extensions=php -n --report=checkstyle --report-file=./build/checkstyle-src.xml
+  - vendor/bin/phpcs --standard=etc/phpcs/ruleset-tests.xml --extensions=php -n --report=checkstyle --report-file=./build/checkstyle-tests.xml
+  - vendor/bin/phpunit -c etc/phpunit/phpunit.xml

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MIEP Public API Client
 
+[![Build Status](https://travis-ci.org/zimmo-be/miep-public-api.svg?branch=master)](https://travis-ci.org/zimmo-be/miep-public-api)
+
 ## Installation
 
 Get your preferred [HTTP Client implementation](https://packagist.org/providers/php-http/client-implementation)


### PR DESCRIPTION
Added a Travis configuration file so tests and codestyle are run using Travis CI. Test results are visible to the public and I also added a badge to the readme that will look like this:

[![Build Status](https://travis-ci.org/webberig/miep-public-api.svg?branch=master)](https://travis-ci.org/webberig/miep-public-api)